### PR TITLE
Added 169.254.x.x info for BGP enabled VPNs

### DIFF
--- a/Cisco/Current/ASR/cisco-asr-ios-15.2-Route_Based.txt
+++ b/Cisco/Current/ASR/cisco-asr-ios-15.2-Route_Based.txt
@@ -68,7 +68,9 @@ crypto ipsec transform-set azure-ipsec-proposal-set esp-aes 256 esp-sha-hmac
 ! you may choose to use a different id.
 ! The IP address 169.254.0.1 acts as the “inner” address of the tunnel. Essentially it has one job, to deliver traffic from the Azure side
 ! to the on-prem side. As it does not need to reach the Internet, it being routable is not necessary. The ASR has an internal routing table
-! and knows what to do with the traffic. You should be able to use any 169.254.X.X address. 
+! and knows what to do with the traffic. You should be able to use any 169.254.X.X address. However if you plan to do a BGP enabled
+! VPN, make sure that the soruce IP of the BGP session is _not_ 169.254.x.x, as the VPN gateway won't form a relationship with it if so.
+! Or if you need to use the tunnel IP as a source, choose an IP address outside 169.254.x.x. 
 
 crypto ipsec profile azure-vti
   set transform-set azure-ipsec-proposal-set
@@ -76,7 +78,7 @@ crypto ipsec profile azure-vti
   exit
 
 int tunnel 1
-  ip address 169.254.0.1 255.255.255.0
+  ip address 169.254.0.1 255.255.255.0 
   ip tcp adjust-mss 1350
   tunnel source <NameOfYourOutsideInterface>
   tunnel mode ipsec ipv4


### PR DESCRIPTION
We don't (seem to) allow connections to 169.254, at least when I tried, it worked as soon as I changed the IP on my end.