### PR TITLE
Updating CIDR of Cisco ASR and ISR template docs referencing Azure Network

### DIFF
--- a/Cisco/Current/ASR/Site-to-Site_VPN_using_Cisco_ASR.md
+++ b/Cisco/Current/ASR/Site-to-Site_VPN_using_Cisco_ASR.md
@@ -3,13 +3,13 @@ This configuration template applies to **Cisco ASR 1000 Series** Aggregation Ser
 - Vpn Type: **RouteBased**
 - Local virtual network gateway Ip Address: **131.X.X.X** (Outside Interface IP Address of ASR or Public IP address)
 - Local Network Prefix: **10.0.0.0/8** (Your on-premises local network. Specify starting IP address of your network.)
-- Azure Virtual Network **192.168.1.0/16**
+- Azure Virtual Network **192.168.0.0/16**
 - Shared Key: **a1af0cdcb0494757a16abe0cc2101c7b**
 
 
 ### ACL rules###
 
-Proper ACL rules are needed for permitting cross-premise network traffic. You should also allow inbound UDP/ESP traffic for the interface which will be used for the IPSec tunnel. In this example **10.0.0.0/8** is the on premises network & **192.168.1.0/16** is the Azure Virtual Network In this example the Azure Gateway IP Address is **40.76.X.X** and your Outside Interface IP Address is **131.X.X.X**
+Proper ACL rules are needed for permitting cross-premise network traffic. You should also allow inbound UDP/ESP traffic for the interface which will be used for the IPSec tunnel. In this example **10.0.0.0/8** is the on premises network & **192.168.0.0/16** is the Azure Virtual Network In this example the Azure Gateway IP Address is **40.76.X.X** and your Outside Interface IP Address is **131.X.X.X**
 
 	access-list 101 permit ip 10.0.0.0 0.255.255.255 192.168.0.0 0.0.255.255
 	access-list 102 permit udp host 40.76.X.X eq isakmp host 131.X.X.X
@@ -18,25 +18,25 @@ Proper ACL rules are needed for permitting cross-premise network traffic. You sh
 ### Internet Key Exchange (IKE) configuration ###
 
 This section specifies the authentication, encryption, hashing, and Diffie-Hellman group parameters for the Phase 1 negotiation and the main mode security association. In this example the Azure Gateway IP Address is **40.76.X.X**
-	
+
 	crypto ikev2 proposal azure-proposal
 	  encryption aes-cbc-256 aes-cbc-128 3des
 	  integrity sha1
 	  group 2
 	  exit
-	
+
 	crypto ikev2 policy azure-policy
 	  proposal azure-proposal
 	  dpd 10 30
 	  exit
-	
+
 	crypto ikev2 keyring azure-keyring
 	  peer 40.76.X.X
 	    address 40.76.X.X
 	    pre-shared-key a1af0cdcb0494757a16abe0cc2101c7b
 		exit
 	  exit
-	
+
 	crypto ikev2 profile azure-profile
 	  match address local interface <NameOfYourOutsideInterface>
 	  match identity remote address 40.76.X.X 255.255.255.255
@@ -55,13 +55,13 @@ This section specifies encryption, authentication, tunnel mode properties for th
 
 ### Crypto map configuration ###
 
-This section defines a crypto profile that binds the cross-premise network traffic to the IPSec transform set and remote peer. We also bind the IPSec policy to the virtual tunnel interface, through which cross-premise traffic will be transmitted. We have picked an arbitrary tunnel id **"1"** as an example. If that happens to conflict with an existing virtual tunnel interface, you may choose to use a different id. The IP address **169.254.0.**1 acts as the “inner” address of the tunnel. Essentially it has one job, to deliver traffic from the Azure side to the on-prem side. As it does not need to reach the Internet, it being routable is not necessary. The ASR has an internal routing table and knows what to do with the traffic. You should be able to use any **169.254.X.X** address. 
+This section defines a crypto profile that binds the cross-premise network traffic to the IPSec transform set and remote peer. We also bind the IPSec policy to the virtual tunnel interface, through which cross-premise traffic will be transmitted. We have picked an arbitrary tunnel id **"1"** as an example. If that happens to conflict with an existing virtual tunnel interface, you may choose to use a different id. The IP address **169.254.0.**1 acts as the “inner” address of the tunnel. Essentially it has one job, to deliver traffic from the Azure side to the on-prem side. As it does not need to reach the Internet, it being routable is not necessary. The ASR has an internal routing table and knows what to do with the traffic. You should be able to use any **169.254.X.X** address.
 
 	crypto ipsec profile azure-vti
 	  set transform-set azure-ipsec-proposal-set
 	  set ikev2-profile azure-profile
 	  exit
-	
+
 	int tunnel 1
 	  ip address 169.254.0.1 255.255.255.0
 	  ip tcp adjust-mss 1350
@@ -70,5 +70,5 @@ This section defines a crypto profile that binds the cross-premise network traff
 	  tunnel destination 40.76.X.X
 	  tunnel protection ipsec profile azure-vti
 	  exit
-	
+
 	ip route 192.168.0.0 255.255.0.0 tunnel 1

--- a/Cisco/Current/ASR/cisco-asr-ios-15.1-Policy_Based.txt
+++ b/Cisco/Current/ASR/cisco-asr-ios-15.1-Policy_Based.txt
@@ -6,15 +6,15 @@
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! ACL rules
-! 
+!
 ! Proper ACL rules are needed for permitting cross-premise network traffic.
 ! You should also allow inbound UDP/ESP traffic for the interface which will be used for the IPSec tunnel.
-! In this example 10.0.0.0/8 is the on premises network & 192.168.1.0/16 is the Azure Virtual Network
+! In this example 10.0.0.0/8 is the on premises network & 192.168.0.0/16 is the Azure Virtual Network
 access-list 101 permit ip 10.0.0.0 0.255.255.255 192.168.0.0 0.0.255.255
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! Internet Key Exchange (IKE) configuration
-! 
+!
 ! This section specifies the authentication, encryption, hashing, Diffie-Hellman, and lifetime parameters for the Phase
 ! 1 negotiation and the main mode security association. We have picked an arbitrary policy # "10" as an example. If
 ! that happens to conflict with an existing policy, you may choose to use a different policy #.
@@ -30,7 +30,7 @@ crypto isakmp key XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX address 40.76.X.X
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! IPSec configuration
-! 
+!
 ! This section specifies encryption, authentication, tunnel mode properties for the Phase 2 negotiation
 crypto ipsec transform-set azure-ipsec-proposal-set esp-aes 256 esp-sha-hmac
  mode tunnel
@@ -49,7 +49,7 @@ crypto map azure-crypto-map 10 ipsec-isakmp
  set transform-set azure-ipsec-proposal-set
  match address 101
  exit
- 
+
 ! ---------------------------------------------------------------------------------------------------------------------
 ! External interface configuration
 !

--- a/Cisco/Current/ASR/cisco-asr-ios-15.2-Route_Based.txt
+++ b/Cisco/Current/ASR/cisco-asr-ios-15.2-Route_Based.txt
@@ -8,10 +8,10 @@
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! ACL rules
-! 
+!
 ! Proper ACL rules are needed for permitting cross-premise network traffic.
 ! You should also allow inbound UDP/ESP traffic for the interface which will be used for the IPSec tunnel.
-! In this example 10.0.0.0/8 is the on premises network & 192.168.1.0/16 is the Azure Virtual Network
+! In this example 10.0.0.0/8 is the on premises network & 192.168.0.0/16 is the Azure Virtual Network
 ! In this example the Azure Gateway IP Address is 40.76.X.X and your Outside Interface IP Address is 131.X.X.X
 
 access-list 101 permit ip 10.0.0.0 0.255.255.255 192.168.0.0 0.0.255.255
@@ -20,9 +20,9 @@ access-list 102 permit esp host 40.76.X.X host 131.X.X.X
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! Internet Key Exchange (IKE) configuration
-! 
+!
 ! This section specifies the authentication, encryption, hashing, and Diffie-Hellman group parameters for the Phase
-! 1 negotiation and the main mode security association. 
+! 1 negotiation and the main mode security association.
 ! In this example the Azure Gateway IP Address is 40.76.X.X
 
 crypto ikev2 proposal azure-proposal
@@ -52,7 +52,7 @@ crypto ikev2 profile azure-profile
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! IPSec configuration
-! 
+!
 ! This section specifies encryption, authentication, tunnel mode properties for the Phase 2 negotiation
 
 crypto ipsec transform-set azure-ipsec-proposal-set esp-aes 256 esp-sha-hmac
@@ -62,15 +62,15 @@ crypto ipsec transform-set azure-ipsec-proposal-set esp-aes 256 esp-sha-hmac
 ! ---------------------------------------------------------------------------------------------------------------------
 ! Crypto map configuration
 !
-! This section defines a crypto profile that binds the cross-premise network traffic to the IPSec transform set and remote peer.  
-! We also bind the IPSec policy to the virtual tunnel interface, through which cross-premise traffic will be transmitted.  
+! This section defines a crypto profile that binds the cross-premise network traffic to the IPSec transform set and remote peer.
+! We also bind the IPSec policy to the virtual tunnel interface, through which cross-premise traffic will be transmitted.
 ! We have picked an arbitrary tunnel id "1" as an example. If that happens to conflict with an existing virtual tunnel interface,
 ! you may choose to use a different id.
 ! The IP address 169.254.0.1 acts as the “inner” address of the tunnel. Essentially it has one job, to deliver traffic from the Azure side
 ! to the on-prem side. As it does not need to reach the Internet, it being routable is not necessary. The ASR has an internal routing table
 ! and knows what to do with the traffic. You should be able to use any 169.254.X.X address. However if you plan to do a BGP enabled
 ! VPN, make sure that the soruce IP of the BGP session is _not_ 169.254.x.x, as the VPN gateway won't form a relationship with it if so.
-! Or if you need to use the tunnel IP as a source, choose an IP address outside 169.254.x.x. 
+! Or if you need to use the tunnel IP as a source, choose an IP address outside 169.254.x.x.
 
 crypto ipsec profile azure-vti
   set transform-set azure-ipsec-proposal-set
@@ -78,7 +78,7 @@ crypto ipsec profile azure-vti
   exit
 
 int tunnel 1
-  ip address 169.254.0.1 255.255.255.0 
+  ip address 169.254.0.1 255.255.255.0
   ip tcp adjust-mss 1350
   tunnel source <NameOfYourOutsideInterface>
   tunnel mode ipsec ipv4

--- a/Cisco/Current/ISR/Site-to-Site_VPN_using_Cisco_ISR.md
+++ b/Cisco/Current/ISR/Site-to-Site_VPN_using_Cisco_ISR.md
@@ -1,4 +1,4 @@
-This configuration template applies to **Cisco ISR 2900** Series Integrated Services Routers running IOS 15.1 or greater. It configures an IPSec **RouteBased** VPN tunnel connecting your on-premise VPN device with the Azure gateway. Things that begin with "azure-" are variable names and can be changed consistently. 
+This configuration template applies to **Cisco ISR 2900** Series Integrated Services Routers running IOS 15.1 or greater. It configures an IPSec **RouteBased** VPN tunnel connecting your on-premise VPN device with the Azure gateway. Things that begin with "azure-" are variable names and can be changed consistently.
 
 ----------
 Note: The Cicso ISR 7200 Series routers only support [PolicyBased](https://github.com/Azure/Azure-vpn-config-samples/blob/master/Cisco/Current/ISR/cisco-isr-ios-15.0-Policy_Based.txt) VPNs.
@@ -8,12 +8,12 @@ Note: The Cicso ISR 7200 Series routers only support [PolicyBased](https://githu
 - Vpn Type: **RouteBased**
 - Local virtual network gateway Ip Address: **131.X.X.X** (Outside Interface IP Address of ISR or Public IP address)
 - Local Network Prefix: **10.0.0.0/8** (Your on-premises local network. Specify starting IP address of your network.)
-- Azure Virtual Network **192.168.1.0/16**
+- Azure Virtual Network **192.168.0.0/16**
 - Shared Key: **a1af0cdcb0494757a16abe0cc2101c7b**
 
 ### ACL rules ###
 
-Proper ACL rules are needed for permitting cross-premise network traffic. You should also allow inbound UDP/ESP traffic for the interface which will be used for the IPSec tunnel. In this example **10.0.0.0/8** is the on premises network & **192.168.1.0/16** is the Azure Virtual Network. In this example the Azure Gateway IP Address is **40.76.X.X** and your Outside Interface IP Address is **131.X.X.X**
+Proper ACL rules are needed for permitting cross-premise network traffic. You should also allow inbound UDP/ESP traffic for the interface which will be used for the IPSec tunnel. In this example **10.0.0.0/8** is the on premises network & **192.168.0.0/16** is the Azure Virtual Network. In this example the Azure Gateway IP Address is **40.76.X.X** and your Outside Interface IP Address is **131.X.X.X**
 
 	access-list 101 permit ip 10.0.0.0 0.255.255.255 192.168.0.0 0.0.255.255
 	access-list 102 permit udp host 40.76.X.X eq isakmp host 131.X.X.X
@@ -60,12 +60,12 @@ This section specifies encryption, authentication, tunnel mode properties for th
 
 This section defines a crypto profile that binds the cross-premise network traffic to the IPSec transform set and remote peer. We also bind the IPSec policy to the virtual tunnel interface, through which cross-premise traffic will be transmitted. We have picked an arbitrary tunnel id "1" as an example. If that happens to conflict with an existing virtual tunnel interface, you may choose to use a different id. The IP address **169.254.0.1** acts as the “inner” address of the tunnel. Essentially it has one job, to deliver traffic from the Azure side to the on-prem side. As it does not need to reach the Internet, it being routable is not necessary. The ISR has an internal routing table and knows what to do with the traffic. You should be able to use any **169.254.X.X** address.
 
- 
+
 	crypto ipsec profile azure-vti
 	  set transform-set azure-ipsec-proposal-set
 	  set ikev2-profile azure-profile
 	  exit
-	
+
 	int tunnel 1
 	  ip address 169.254.0.1 255.255.255.0
 	  ip tcp adjust-mss 1350
@@ -74,5 +74,5 @@ This section defines a crypto profile that binds the cross-premise network traff
 	  tunnel destination 40.76.X.X
 	  tunnel protection ipsec profile azure-vti
 	  exit
-	
+
 	ip route 192.168.0.0 255.255.0.0 tunnel 1

--- a/Cisco/Current/ISR/cisco-isr-ios-15.0-Policy_Based.txt
+++ b/Cisco/Current/ISR/cisco-isr-ios-15.0-Policy_Based.txt
@@ -6,15 +6,15 @@
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! ACL rules
-! 
+!
 ! Proper ACL rules are needed for permitting cross-premise network traffic.
 ! You should also allow inbound UDP/ESP traffic for the interface which will be used for the IPSec tunnel.
-! In this example 10.0.0.0/8 is the on premises network & 192.168.1.0/16 is the Azure Virtual Network
+! In this example 10.0.0.0/8 is the on premises network & 192.168.0.0/16 is the Azure Virtual Network
 access-list 101 permit ip 10.0.0.0 0.255.255.255 192.168.0.0 0.0.255.255
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! Internet Key Exchange (IKE) configuration
-! 
+!
 ! This section specifies the authentication, encryption, hashing, Diffie-Hellman, and lifetime parameters for the Phase
 ! 1 negotiation and the main mode security association. We have picked an arbitrary policy # "10" as an example. If
 ! that happens to conflict with an existing policy, you may choose to use a different policy #.
@@ -30,7 +30,7 @@ crypto isakmp key XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX address 40.76.X.X
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! IPSec configuration
-! 
+!
 ! This section specifies encryption, authentication, tunnel mode properties for the Phase 2 negotiation
 crypto ipsec transform-set azure-ipsec-proposal-set esp-aes 256 esp-sha-hmac
  mode tunnel

--- a/Cisco/Current/ISR/cisco-isr-ios-15.1-Route_Based.txt
+++ b/Cisco/Current/ISR/cisco-isr-ios-15.1-Route_Based.txt
@@ -8,10 +8,10 @@
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! ACL rules
-! 
+!
 ! Proper ACL rules are needed for permitting cross-premise network traffic.
 ! You should also allow inbound UDP/ESP traffic for the interface which will be used for the IPSec tunnel.
-! In this example 10.0.0.0/8 is the on premises network & 192.168.1.0/16 is the Azure Virtual Network
+! In this example 10.0.0.0/8 is the on premises network & 192.168.0.0/16 is the Azure Virtual Network
 ! In this example the Azure Gateway IP Address is 40.76.X.X and your Outside Interface IP Address is 131.X.X.X
 
 access-list 101 permit ip 10.0.0.0 0.255.255.255 192.168.0.0 0.0.255.255
@@ -20,9 +20,9 @@ access-list 102 permit esp host 40.76.X.X host 131.X.X.X
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! Internet Key Exchange (IKE) configuration
-! 
+!
 ! This section specifies the authentication, encryption, hashing, and Diffie-Hellman group parameters for the Phase
-! 1 negotiation and the main mode security association. 
+! 1 negotiation and the main mode security association.
 ! In this example the Azure Gateway IP Address is 40.76.X.X
 
 crypto ikev2 proposal azure-proposal
@@ -52,7 +52,7 @@ crypto ikev2 profile azure-profile
 
 ! ---------------------------------------------------------------------------------------------------------------------
 ! IPSec configuration
-! 
+!
 ! This section specifies encryption, authentication, tunnel mode properties for the Phase 2 negotiation
 
 crypto ipsec transform-set azure-ipsec-proposal-set esp-aes 256 esp-sha-hmac
@@ -62,13 +62,13 @@ crypto ipsec transform-set azure-ipsec-proposal-set esp-aes 256 esp-sha-hmac
 ! ---------------------------------------------------------------------------------------------------------------------
 ! Crypto map configuration
 !
-! This section defines a crypto profile that binds the cross-premise network traffic to the IPSec transform set and remote peer.  
-! We also bind the IPSec policy to the virtual tunnel interface, through which cross-premise traffic will be transmitted.  
+! This section defines a crypto profile that binds the cross-premise network traffic to the IPSec transform set and remote peer.
+! We also bind the IPSec policy to the virtual tunnel interface, through which cross-premise traffic will be transmitted.
 ! We have picked an arbitrary tunnel id "1" as an example. If that happens to conflict with an existing virtual tunnel interface,
 ! you may choose to use a different id.
 ! The IP address 169.254.0.1 acts as the “inner” address of the tunnel. Essentially it has one job, to deliver traffic from the Azure side
 ! to the on-prem side. As it does not need to reach the Internet, it being routable is not necessary. The ISR has an internal routing table
-! and knows what to do with the traffic. You should be able to use any 169.254.X.X address. 
+! and knows what to do with the traffic. You should be able to use any 169.254.X.X address.
 
 crypto ipsec profile azure-vti
   set transform-set azure-ipsec-proposal-set


### PR DESCRIPTION
The Cisco ASR and ISR documentation incorrectly lists 192.168.1.0/16 as the subnet
to use when it's really 192.168.0.0/16 in the configs. This change is purely an
update to documentation and does not impact the function of any of the templates.

The other changes are just removing of trailing spaces that aren't needed.