### PR TITLE
Azure only supports DH Group 2 by default and StrongSwan has deprecated it

### DIFF
--- a/StrongSwan/5.3.5/ipsec.conf
+++ b/StrongSwan/5.3.5/ipsec.conf
@@ -12,3 +12,10 @@ conn azure
         rightsubnet=10.11.0.0/16,10.12.0.0/16 #Azure VNET address space
         auto=route
         keyexchange=ikev2 # Mandatory for Dynamic / Route-based gateway
+        # By Default Azure VPN gateways only accept DH Group 2 (-modp1024). Since StrongSwan has
+        # deprecated DH Group 2 we need to manually add it in.
+        # SECURITY WARNING:
+        # DH Group 2 is now considered insecure, you should add a Connection policy on
+        # Azure side that uses DH Group 24 (-modp2048s256) or a more secure one (EC).
+        # Use strongswan stroke up <connection_name> to see if proposals match.
+        ike=aes256-sha384-modp1024


### PR DESCRIPTION
By Default Azure VPN gateways only accept DH Group 2 (-modp1024). Since StrongSwan has deprecated DH Group 2 we need to manually add it in.

## SECURITY WARNING:
DH Group 2 is now considered insecure, you should add a Connection policy on Azure side that uses DH Group 24 (-modp2048s256) or a more secure one (EC).

```
        ike=aes256-sha384-modp1024
```